### PR TITLE
Add capabilities attribute for printers and ticket option for print jobs

### DIFF
--- a/lib/cloudprint/print_job.rb
+++ b/lib/cloudprint/print_job.rb
@@ -49,7 +49,8 @@ module CloudPrint
           :create_time => Time.at(response_hash['createTime'].to_f / 1000),
           :update_time => Time.at(response_hash['updateTime'].to_f / 1000),
           :message => response_hash['message'],
-          :tags => response_hash['tags']
+          :tags => response_hash['tags'],
+          :ticket => response_hash['ticket']
         }
       end
     end

--- a/lib/cloudprint/printer.rb
+++ b/lib/cloudprint/printer.rb
@@ -2,9 +2,9 @@ module CloudPrint
   class Printer
     CONNECTION_STATUSES = %w{ONLINE UNKNOWN OFFLINE DORMANT}
     CONFIG_OPTS = [:id, :status, :name, :tags, :display_name, :client, :connection_status, :description, :capabilities]
-    
+
     attr_reader *CONFIG_OPTS
-    
+
     def initialize(options = {})
       @client = options[:client]
       @id = options[:id]
@@ -19,7 +19,7 @@ module CloudPrint
 
     def print(options)
       method = options[:content].is_a?(IO) ? :multipart_post : :post
-      response = client.connection.send(method, '/submit', :printerid => self.id, :title => options[:title], :content => options[:content], :ticket => options[:ticket], :contentType => options[:content_type]) || {}
+      response = client.connection.send(method, '/submit', :printerid => self.id, :title => options[:title], :content => options[:content], :ticket => options[:ticket].to_json, :contentType => options[:content_type]) || {}
       return nil if response.nil? || response["job"].nil?
       client.print_jobs.new_from_response response["job"]
     end

--- a/lib/cloudprint/printer.rb
+++ b/lib/cloudprint/printer.rb
@@ -1,7 +1,7 @@
 module CloudPrint
   class Printer
     CONNECTION_STATUSES = %w{ONLINE UNKNOWN OFFLINE DORMANT}
-    CONFIG_OPTS = [:id, :status, :name, :tags, :display_name, :client, :connection_status, :description]
+    CONFIG_OPTS = [:id, :status, :name, :tags, :display_name, :client, :connection_status, :description, :capabilities]
     
     attr_reader *CONFIG_OPTS
     
@@ -14,6 +14,7 @@ module CloudPrint
       @tags = options[:tags] || {}
       @connection_status = options[:connection_status] || 'UNKNOWN'
       @description = options[:description]
+      @capabilities = options[:capabilities]
     end
 
     def print(options)

--- a/lib/cloudprint/printer.rb
+++ b/lib/cloudprint/printer.rb
@@ -19,7 +19,7 @@ module CloudPrint
 
     def print(options)
       method = options[:content].is_a?(IO) ? :multipart_post : :post
-      response = client.connection.send(method, '/submit', :printerid => self.id, :title => options[:title], :content => options[:content], :contentType => options[:content_type]) || {}
+      response = client.connection.send(method, '/submit', :printerid => self.id, :title => options[:title], :content => options[:content], :ticket => options[:ticket], :contentType => options[:content_type]) || {}
       return nil if response.nil? || response["job"].nil?
       client.print_jobs.new_from_response response["job"]
     end

--- a/lib/cloudprint/printer_collection.rb
+++ b/lib/cloudprint/printer_collection.rb
@@ -45,7 +45,8 @@ module CloudPrint
         display_name: hash['displayName'],
         tags: hash['tags'],
         connection_status: hash['connectionStatus'],
-        description: hash['description']
+        description: hash['description'],
+        capabilities: hash['capabilities']
         )
     end
   end

--- a/test/printer_test.rb
+++ b/test/printer_test.rb
@@ -1,4 +1,5 @@
 require "helper"
+require "test/unit"
 class PrinterTest < Test::Unit::TestCase
   def setup
     @client = new_client
@@ -180,11 +181,11 @@ class PrinterTest < Test::Unit::TestCase
   end
 
   def print_params
-     { :title => "Hello World", :content => "<h1>ohai!</h1>", :content_type => "text/html" }
+     { :title => "Hello World", :content => "<h1>ohai!</h1>", :content_type => "text/html", :ticket => ticket_hash }
   end
 
   def connection_print_params
-    { :printerid => 'printer', :title => "Hello World", :content => "<h1>ohai!</h1>", :contentType => "text/html" }
+    { :printerid => 'printer', :title => "Hello World", :content => "<h1>ohai!</h1>", :contentType => "text/html", :ticket => ticket_hash }
   end
 
   def print_file
@@ -193,11 +194,11 @@ class PrinterTest < Test::Unit::TestCase
   end
 
   def print_file_params
-    { :title => "Ruby!", :content => ruby_png_fixture, :content_type => "image/png" }
+    { :title => "Ruby!", :content => ruby_png_fixture, :content_type => "image/png", :ticket => ticket_hash }
   end
 
   def connection_print_file_params
-    { :printerid => 'printer', :title => "Ruby!", :content => ruby_png_fixture, :contentType => "image/png" }
+    { :printerid => 'printer', :title => "Ruby!", :content => ruby_png_fixture, :contentType => "image/png", :ticket => ticket_hash }
   end
 
   def one_printer_hash
@@ -209,6 +210,20 @@ class PrinterTest < Test::Unit::TestCase
         {'id' => 'first_printer',  'status' => 'online', 'name' => "First Printer", 'displayName' => 'First Printer (display name)', 'description' => 'First printer description'},
         {'id' => 'second_printer', 'status' => 'online', 'name' => "Second Printer", 'displayName' => 'Second Printer (display name)', 'description' => 'Second printer description'}
     ]}
+  end
+  
+  def ticket_hash 
+    { 'version' => '1.0', 
+      'print' => { 
+        'vendor_ticket_item' => [
+          {'id' => 'PageRegion', 'value' => "Letter"},
+          {'id' => 'BRMediaType', 'value' => 'Plain'},
+          {'id' => 'InputSlot', 'value' => 'Tray1'} 
+        ],
+        'page_orientation' => {'type' => 2},
+        'fit_to_page' => {'type' => 3}
+      }
+    }    
   end
 
   def ruby_png_fixture

--- a/test/printer_test.rb
+++ b/test/printer_test.rb
@@ -185,7 +185,7 @@ class PrinterTest < Test::Unit::TestCase
   end
 
   def connection_print_params
-    { :printerid => 'printer', :title => "Hello World", :content => "<h1>ohai!</h1>", :contentType => "text/html", :ticket => ticket_hash }
+    { :printerid => 'printer', :title => "Hello World", :content => "<h1>ohai!</h1>", :contentType => "text/html", :ticket => ticket_hash.to_json }
   end
 
   def print_file
@@ -198,7 +198,7 @@ class PrinterTest < Test::Unit::TestCase
   end
 
   def connection_print_file_params
-    { :printerid => 'printer', :title => "Ruby!", :content => ruby_png_fixture, :contentType => "image/png", :ticket => ticket_hash }
+    { :printerid => 'printer', :title => "Ruby!", :content => ruby_png_fixture, :contentType => "image/png", :ticket => ticket_hash.to_json }
   end
 
   def one_printer_hash
@@ -211,19 +211,19 @@ class PrinterTest < Test::Unit::TestCase
         {'id' => 'second_printer', 'status' => 'online', 'name' => "Second Printer", 'displayName' => 'Second Printer (display name)', 'description' => 'Second printer description'}
     ]}
   end
-  
-  def ticket_hash 
-    { 'version' => '1.0', 
-      'print' => { 
+
+  def ticket_hash
+    { 'version' => '1.0',
+      'print' => {
         'vendor_ticket_item' => [
           {'id' => 'PageRegion', 'value' => "Letter"},
           {'id' => 'BRMediaType', 'value' => 'Plain'},
-          {'id' => 'InputSlot', 'value' => 'Tray1'} 
+          {'id' => 'InputSlot', 'value' => 'Tray1'}
         ],
         'page_orientation' => {'type' => 2},
         'fit_to_page' => {'type' => 3}
       }
-    }    
+    }
   end
 
   def ruby_png_fixture


### PR DESCRIPTION
Added the capabilities response to the printer object and the ticket option for print jobs. 
Now its possible to send printer settings with the job. For example: 

```ruby
printer_options = { version: "1.0", print: { fit_to_page: {type: 3} } }.to_json
job = my_printer.print(content: url, content_type: "url", ticket: printer_options)
```