### PR TITLE
Allow various IO wrapper types as input

### DIFF
--- a/lib/cloudprint/printer.rb
+++ b/lib/cloudprint/printer.rb
@@ -18,7 +18,8 @@ module CloudPrint
     end
 
     def print(options)
-      method = options[:content].is_a?(IO) ? :multipart_post : :post
+      content = options[:content]
+      method = content.is_a?(IO) || content.is_a?(StringIO) || content.is_a?(Tempfile) ? :multipart_post : :post
       response = client.connection.send(method, '/submit', :printerid => self.id, :title => options[:title], :content => options[:content], :ticket => options[:ticket].to_json, :contentType => options[:content_type]) || {}
       return nil if response.nil? || response["job"].nil?
       client.print_jobs.new_from_response response["job"]

--- a/test/printer_test.rb
+++ b/test/printer_test.rb
@@ -95,6 +95,26 @@ class PrinterTest < Minitest::Test
     print_file
   end
 
+  should "print stringio" do
+    stringio = StringIO.new(ruby_png_fixture.read)
+
+    fake_connection.expects(:multipart_post).with('/submit', connection_print_file_params.merge(:content => stringio)).returns(empty_job)
+    stub_connection
+
+    printer = @client.printers.new(:id => 'printer')
+    printer.print(print_file_params.merge(:content => stringio))
+  end
+
+  should "print tempfile" do
+    Tempfile.open "cloundprint_test" do |tempfile|
+      fake_connection.expects(:multipart_post).with('/submit', connection_print_file_params.merge(:content => tempfile)).returns(empty_job)
+      stub_connection
+
+      printer = @client.printers.new(:id => 'printer')
+      printer.print(print_file_params.merge(:content => tempfile))
+    end
+  end
+
   should "print jobs returning an id and a status" do
     stub_connection
     fake_connection.expects(:post).with('/submit', connection_print_params).returns({"success" => true, "job" => {"id" => "job_id", "status" => 'status'}})


### PR DESCRIPTION
For reasons unfathomable by mere mortals, in Ruby neither StringIO nor Tempfile are instances of IO. E.g.: `StringIO.new("").is_a?(IO) == false`. This means that it isn't possible to call `printer#print` with one of these as input. This changes that.